### PR TITLE
Implement time accumulation

### DIFF
--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -12,7 +12,7 @@ pub struct PhysicsStepperSystem {
 impl Default for PhysicsStepperSystem {
     fn default() -> Self {
         PhysicsStepperSystem {
-            intended_timestep: 1.0 / 120.0,
+            intended_timestep: 1.0 / 60.0,
             max_timesteps: 10,
             time_accumulator: 0.,
         }

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -6,6 +6,7 @@ use amethyst::ecs::{Read, System, WriteExpect};
 pub struct PhysicsStepperSystem {
     intended_timestep: f32,
     max_timesteps: i32,
+    time_accumulator: f32,
 }
 
 impl Default for PhysicsStepperSystem {
@@ -13,6 +14,7 @@ impl Default for PhysicsStepperSystem {
         PhysicsStepperSystem {
             intended_timestep: 1.0 / 120.0,
             max_timesteps: 10,
+            time_accumulator: 0.,
         }
     }
 }
@@ -22,6 +24,7 @@ impl PhysicsStepperSystem {
         PhysicsStepperSystem {
             intended_timestep,
             max_timesteps,
+            time_accumulator: 0.,
         }
     }
 }
@@ -36,12 +39,12 @@ impl<'a> System<'a> for PhysicsStepperSystem {
             physical_world.set_timestep(self.intended_timestep);
         }
 
-        let mut delta = time.delta_seconds();
+        self.time_accumulator += time.delta_seconds();
         let mut steps = 0;
 
-        while steps <= self.max_timesteps && delta >= self.intended_timestep {
+        while steps <= self.max_timesteps && self.time_accumulator >= self.intended_timestep {
             physical_world.step();
-            delta -= self.intended_timestep;
+            self.time_accumulator -= self.intended_timestep;
             steps += 1;
         }
     }


### PR DESCRIPTION
This PR adds a simple time accumulation in the `PhysicsStepperSystem`. This change makes sure that physics steps happen correctly and don't get out of sync with real time. 

Previously, the physics timestep of 1/120 seconds would have been run 1 or 2 times at 60 FPS, depending on whether the frame took longer than 1/60 seconds or not. If the second physics step was missed, it was just dropped and the physics went one step out of sync with real time.  
This change also allows choosing a timestep of 1/60 seconds as a more sensible default to save a bit of calculation. Even physics timesteps like 1/20 seconds are possible with this PR.