### PR TITLE
Semi-fixed timestep

### DIFF
--- a/examples/amethyst.rs
+++ b/examples/amethyst.rs
@@ -178,7 +178,9 @@ fn main() -> amethyst::Result<()> {
                 .with_dep(&["transform_system"])
                 .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(
                     vec![1. / 240., 1. / 120., 1. / 60.],
-                    0.3,
+                    0.4,
+                    Duration::from_millis(50),
+                    Duration::from_millis(500),
                 )))
                 .with_max_timesteps(20),
         )?

--- a/examples/amethyst.rs
+++ b/examples/amethyst.rs
@@ -176,10 +176,11 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             PhysicsBundle::new()
                 .with_dep(&["transform_system"])
-                .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(
-                    vec![1. / 240., 1. / 120., 1. / 60.],
-                    Duration::from_millis(1000),
-                )))
+                .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(vec![
+                    1. / 240.,
+                    1. / 120.,
+                    1. / 60.,
+                ])))
                 .with_max_timesteps(20),
         )?
         .with_bundle(RenderBundle::new(pipe, Some(display_config)))?;

--- a/examples/amethyst.rs
+++ b/examples/amethyst.rs
@@ -16,6 +16,7 @@ use nphysics_ecs_dumb::nphysics::object::Material as PhysicsMaterial;
 use nphysics_ecs_dumb::nphysics::volumetric::Volumetric;
 use nphysics_ecs_dumb::*;
 use num_traits::identities::One;
+use std::time::Duration;
 
 struct GameState;
 
@@ -172,7 +173,15 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
-        .with_bundle(PhysicsBundle::new().with_dep(&["transform_system"]))?
+        .with_bundle(
+            PhysicsBundle::new()
+                .with_dep(&["transform_system"])
+                .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(
+                    vec![1. / 240., 1. / 120., 1. / 60.],
+                    Duration::from_millis(1000),
+                )))
+                .with_max_timesteps(20),
+        )?
         .with_bundle(RenderBundle::new(pipe, Some(display_config)))?;
 
     let application = Application::new("./", GameState, game_data);

--- a/examples/amethyst.rs
+++ b/examples/amethyst.rs
@@ -176,11 +176,10 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             PhysicsBundle::new()
                 .with_dep(&["transform_system"])
-                .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(vec![
-                    1. / 240.,
-                    1. / 120.,
-                    1. / 60.,
-                ])))
+                .with_timestep(TimeStep::SemiFixed(TimeStepConstraint::new(
+                    vec![1. / 240., 1. / 120., 1. / 60.],
+                    0.3,
+                )))
                 .with_max_timesteps(20),
         )?
         .with_bundle(RenderBundle::new(pipe, Some(display_config)))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@ extern crate log;
 pub mod bodies;
 pub mod colliders;
 pub mod systems;
+pub mod time_step;
 
 pub use self::bodies::*;
 pub use self::colliders::*;
 pub use self::systems::*;
+pub use self::time_step::*;
 
 /// The Physical World containing all physical objects.
 pub type PhysicsWorld = self::nphysics::world::World<f32>;

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -24,7 +24,7 @@ pub const SYNC_BODIES_FROM_PHYSICS_SYSTEM: &str = "sync_bodies_from_physics_syst
 pub struct PhysicsBundle<'a> {
     dep: &'a [&'a str],
     timestep: TimeStep,
-    max_timesteps: i32,
+    timestep_iter_limit: i32,
 }
 
 impl Default for PhysicsBundle<'_> {
@@ -32,7 +32,7 @@ impl Default for PhysicsBundle<'_> {
         Self {
             dep: Default::default(),
             timestep: Default::default(),
-            max_timesteps: 10,
+            timestep_iter_limit: 10,
         }
     }
 }
@@ -54,8 +54,8 @@ impl<'a> PhysicsBundle<'a> {
     }
 
     /// Set the maximum number of physics timesteps to simulate in a single run of the `PhysicsStepperSystem`
-    pub fn with_max_timesteps(mut self, max_timesteps: i32) -> Self {
-        self.max_timesteps = max_timesteps;
+    pub fn with_timestep_iter_limit(mut self, timestep_iter_limit: i32) -> Self {
+        self.timestep_iter_limit = timestep_iter_limit;
         self
     }
 }
@@ -80,7 +80,7 @@ impl<'a, 'b, 'c> SystemBundle<'a, 'b> for PhysicsBundle<'c> {
         );
 
         builder.add(
-            PhysicsStepperSystem::new(self.timestep, self.max_timesteps),
+            PhysicsStepperSystem::new(self.timestep, self.timestep_iter_limit),
             PHYSICS_STEPPER_SYSTEM,
             &[
                 SYNC_BODIES_TO_PHYSICS_SYSTEM,

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -7,6 +7,8 @@ mod sync_gravity_to_physics;
 use amethyst::core::bundle::{Result, SystemBundle};
 use amethyst::core::specs::DispatcherBuilder;
 
+use crate::time_step::TimeStep;
+
 pub use self::physics_stepper::PhysicsStepperSystem;
 pub use self::sync_bodies_from_physics::*;
 pub use self::sync_bodies_to_physics::SyncBodiesToPhysicsSystem;
@@ -19,9 +21,20 @@ pub const SYNC_COLLIDERS_TO_PHYSICS_SYSTEM: &str = "sync_colliders_to_physics_sy
 pub const PHYSICS_STEPPER_SYSTEM: &str = "physics_stepper_system";
 pub const SYNC_BODIES_FROM_PHYSICS_SYSTEM: &str = "sync_bodies_from_physics_system";
 
-#[derive(Default)]
 pub struct PhysicsBundle<'a> {
     dep: &'a [&'a str],
+    timestep: TimeStep,
+    max_timesteps: i32,
+}
+
+impl Default for PhysicsBundle<'_> {
+    fn default() -> Self {
+        Self {
+            dep: Default::default(),
+            timestep: Default::default(),
+            max_timesteps: 10,
+        }
+    }
 }
 
 impl<'a> PhysicsBundle<'a> {
@@ -31,6 +44,18 @@ impl<'a> PhysicsBundle<'a> {
 
     pub fn with_dep(mut self, dep: &'a [&'a str]) -> Self {
         self.dep = dep;
+        self
+    }
+
+    /// Set the timestep to use for the `PhysicsStepperSystem`
+    pub fn with_timestep(mut self, timestep: TimeStep) -> Self {
+        self.timestep = timestep;
+        self
+    }
+
+    /// Set the maximum number of physics timesteps to simulate in a single run of the `PhysicsStepperSystem`
+    pub fn with_max_timesteps(mut self, max_timesteps: i32) -> Self {
+        self.max_timesteps = max_timesteps;
         self
     }
 }
@@ -55,7 +80,7 @@ impl<'a, 'b, 'c> SystemBundle<'a, 'b> for PhysicsBundle<'c> {
         );
 
         builder.add(
-            PhysicsStepperSystem::default(),
+            PhysicsStepperSystem::new(self.timestep, self.max_timesteps),
             PHYSICS_STEPPER_SYSTEM,
             &[
                 SYNC_BODIES_TO_PHYSICS_SYSTEM,

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -56,7 +56,7 @@ impl<'a> System<'a> for PhysicsStepperSystem {
         if steps > self.max_timesteps {
             if let TimeStep::SemiFixed(constraint) = &mut self.intended_timestep {
                 match constraint.increase_timestep() {
-                    Err(error) => warn!("Failed to raised physics timestep! Error: {}", error),
+                    Err(error) => warn!("Failed to raise physics timestep! Error: {}", error),
                     Ok(timestep) => {
                         physical_world.set_timestep(timestep);
                         info!("Raised physics timestep to {} seconds", timestep);

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -1,10 +1,11 @@
+use crate::time_step::TimeStep;
 use crate::PhysicsWorld;
 use amethyst::core::Time;
 use amethyst::ecs::{Read, System, WriteExpect};
 
 /// Simulates a step of the physics world.
 pub struct PhysicsStepperSystem {
-    intended_timestep: f32,
+    intended_timestep: TimeStep,
     max_timesteps: i32,
     time_accumulator: f32,
 }
@@ -12,7 +13,7 @@ pub struct PhysicsStepperSystem {
 impl Default for PhysicsStepperSystem {
     fn default() -> Self {
         PhysicsStepperSystem {
-            intended_timestep: 1.0 / 60.0,
+            intended_timestep: TimeStep::Fixed(1. / 120.),
             max_timesteps: 10,
             time_accumulator: 0.,
         }
@@ -20,7 +21,7 @@ impl Default for PhysicsStepperSystem {
 }
 
 impl PhysicsStepperSystem {
-    pub fn new(intended_timestep: f32, max_timesteps: i32) -> Self {
+    pub fn new(intended_timestep: TimeStep, max_timesteps: i32) -> Self {
         PhysicsStepperSystem {
             intended_timestep,
             max_timesteps,
@@ -34,18 +35,33 @@ impl<'a> System<'a> for PhysicsStepperSystem {
 
     // Simulate world using the current time frame
     fn run(&mut self, (mut physical_world, time): Self::SystemData) {
-        if physical_world.timestep() != self.intended_timestep {
+        let timestep = match &self.intended_timestep {
+            TimeStep::Fixed(timestep) => *timestep,
+            TimeStep::SemiFixed(constraint) => constraint.current_timestep(),
+        };
+        if physical_world.timestep() != timestep {
             warn!("Physics world timestep out of sync with intended timestep! Leave me alone!!!");
-            physical_world.set_timestep(self.intended_timestep);
+            physical_world.set_timestep(timestep);
         }
 
         self.time_accumulator += time.delta_seconds();
         let mut steps = 0;
 
-        while steps <= self.max_timesteps && self.time_accumulator >= self.intended_timestep {
+        while steps <= self.max_timesteps && self.time_accumulator >= timestep {
             physical_world.step();
-            self.time_accumulator -= self.intended_timestep;
+            self.time_accumulator -= timestep;
             steps += 1;
+        }
+
+        if steps > self.max_timesteps {
+            if let TimeStep::SemiFixed(constraint) = &mut self.intended_timestep {
+                if let Err(error) = constraint.increase_timestep() {
+                    warn!("Failed to raised physics timestep! Error: {}", error);
+                } else {
+                    physical_world.set_timestep(constraint.current_timestep());
+                    info!("Raised physics timestep");
+                }
+            }
         }
     }
 }

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -49,8 +49,10 @@ impl<'a> System<'a> for PhysicsStepperSystem {
                 if let Some(avg_step) = self.avg_step_time {
                     // If the timestep is smaller than it takes to simulate that step, we have a problem.
                     // As simulated time is affected by the time scale, simulated time step / time scale
-                    // is the maximum real time the step may take, so we take that into account here.
-                    let adjusted_step_time = avg_step * time.time_scale();
+                    // is the maximum real time the step may take, so we take that into account here. We
+                    // also take into account the maximum fraction of time physics are allowed to take
+                    let adjusted_step_time =
+                        avg_step * time.time_scale() / constraint.max_physics_time_fraction();
                     if constraint.current_timestep() < adjusted_step_time {
                         match constraint.increase_timestep() {
                             Err(error) => {

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -13,7 +13,7 @@ const TIME_STEP_DECREASE_HYSTERESIS: f32 = 1.5;
 /// Simulates a step of the physics world.
 pub struct PhysicsStepperSystem {
     intended_timestep: TimeStep,
-    max_timesteps: i32,
+    timestep_iter_limit: i32,
     time_accumulator: f32,
     avg_step_time: Option<f32>,
 }
@@ -22,7 +22,7 @@ impl Default for PhysicsStepperSystem {
     fn default() -> Self {
         PhysicsStepperSystem {
             intended_timestep: TimeStep::Fixed(1. / 120.),
-            max_timesteps: 10,
+            timestep_iter_limit: 10,
             time_accumulator: 0.,
             avg_step_time: None,
         }
@@ -30,10 +30,10 @@ impl Default for PhysicsStepperSystem {
 }
 
 impl PhysicsStepperSystem {
-    pub fn new(intended_timestep: TimeStep, max_timesteps: i32) -> Self {
+    pub fn new(intended_timestep: TimeStep, timestep_iter_limit: i32) -> Self {
         PhysicsStepperSystem {
             intended_timestep,
-            max_timesteps,
+            timestep_iter_limit,
             time_accumulator: 0.,
             avg_step_time: None,
         }
@@ -104,7 +104,7 @@ impl<'a> System<'a> for PhysicsStepperSystem {
         self.time_accumulator += time.delta_seconds();
         let mut steps = 0;
 
-        while steps <= self.max_timesteps && self.time_accumulator >= timestep {
+        while steps <= self.timestep_iter_limit && self.time_accumulator >= timestep {
             let physics_time = Instant::now();
 
             physical_world.step();
@@ -129,7 +129,7 @@ impl<'a> System<'a> for PhysicsStepperSystem {
             self.avg_step_time.unwrap_or_default()
         );
 
-        if steps > self.max_timesteps {
+        if steps > self.timestep_iter_limit {
             // This shouldn't normally happen. If it does, one of the following might be true:
             // - TimeStep::Fixed was chosen too small
             // - TimeStep::SemiFixed can't increase the timestep

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -55,11 +55,12 @@ impl<'a> System<'a> for PhysicsStepperSystem {
 
         if steps > self.max_timesteps {
             if let TimeStep::SemiFixed(constraint) = &mut self.intended_timestep {
-                if let Err(error) = constraint.increase_timestep() {
-                    warn!("Failed to raised physics timestep! Error: {}", error);
-                } else {
-                    physical_world.set_timestep(constraint.current_timestep());
-                    info!("Raised physics timestep");
+                match constraint.increase_timestep() {
+                    Err(error) => warn!("Failed to raised physics timestep! Error: {}", error),
+                    Ok(timestep) => {
+                        physical_world.set_timestep(timestep);
+                        info!("Raised physics timestep to {} seconds", timestep);
+                    }
                 }
             }
         }

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -101,7 +101,7 @@ impl<'a> System<'a> for PhysicsStepperSystem {
             steps += 1;
         }
 
-        debug!(
+        trace!(
             "Average time per physics step: {:.8} seconds",
             self.avg_step_time.unwrap_or_default()
         );

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -20,9 +20,14 @@ impl Default for TimeStep {
 /// Error when trying to change the actual timestep for a semi-fixed timestep.
 #[derive(Debug)]
 pub enum TimeStepChangeError {
+    /// No smaller timestep available.
     MinimumTimestepReached,
+    /// No larger timestep available.
     MaximumTimestepReached,
-    MinimumAgeNotReached(Duration),
+    /// Physics haven't been running slow for long enough to change the timestep.
+    MinimumTimeNotReached(Duration),
+    /// Physics aren't running slow.
+    NotRunningSlow,
 }
 
 impl std::fmt::Display for TimeStepChangeError {
@@ -34,10 +39,11 @@ impl std::fmt::Display for TimeStepChangeError {
             TimeStepChangeError::MinimumTimestepReached => {
                 write!(f, "No smaller timestep available!")
             }
-            TimeStepChangeError::MinimumAgeNotReached(remaining) => {
+            TimeStepChangeError::MinimumTimeNotReached(remaining) => {
                 let time = remaining.as_secs() as f32 + remaining.subsec_nanos() as f32 * 1e-9;
                 write!(f, "Timestep can be changed in {:.4} seconds", time)
             }
+            TimeStepChangeError::NotRunningSlow => write!(f, "Simulation is not running slow"),
         }
     }
 }
@@ -48,19 +54,21 @@ pub struct TimeStepConstraint {
     time_steps: Vec<f32>,
     /// Index of the currently used timestep.
     current_index: usize,
-    /// Time when the timestep was last changed.
-    change_time: Instant,
-    /// Minimum time after changing the timestep before it can be changed again.
-    minimum_age: Duration,
+    /// Time when the simulation started running slow.
+    running_slow_since: Option<Instant>,
+    /// Minimum time the simulation has to be running slow before the timestep is changed.
+    minimum_slow_time: Duration,
 }
 
 impl TimeStepConstraint {
-    /// Creates a new `TimeStepConstraint` from the specified timesteps to use and the minimum time between changing timesteps.
+    /// Creates a new `TimeStepConstraint` from the specified timesteps to use and the minimum time of running
+    /// slowly before changing timesteps. The timestep will be increased if physics have been lagging behind for
+    /// the last `minimum_slow_time`.
     ///
     /// # Panics
     ///
     /// This constructor will panic if no timesteps are given or if any negative timesteps are specified.
-    pub fn new(time_steps: impl Into<Vec<f32>>, minimum_age: Duration) -> Self {
+    pub fn new(time_steps: impl Into<Vec<f32>>, minimum_slow_time: Duration) -> Self {
         let mut time_steps = time_steps.into();
         assert!(
             !time_steps.is_empty(),
@@ -73,39 +81,84 @@ impl TimeStepConstraint {
         Self {
             time_steps,
             current_index: 0,
-            change_time: Instant::now(),
-            minimum_age,
+            minimum_slow_time,
+            running_slow_since: None,
         }
     }
 
     /// Increase the timestep. This corresponds to fewer updates per second.
+    ///
+    /// Shouldn't be called from outside the `PhysicsStepperSystem`, otherwise bad things may happen.
     pub fn increase_timestep(&mut self) -> Result<f32, TimeStepChangeError> {
         if self.current_index >= self.time_steps.len() - 1 {
             return Err(TimeStepChangeError::MaximumTimestepReached);
         }
-        if let Some(remaining) = self.minimum_age.checked_sub(self.change_time.elapsed()) {
-            return Err(TimeStepChangeError::MinimumAgeNotReached(remaining));
+        let running_slow_since = match self.running_slow_since {
+            Some(time) => time,
+            None => return Err(TimeStepChangeError::NotRunningSlow),
+        };
+        if let Some(remaining) = self
+            .minimum_slow_time
+            .checked_sub(running_slow_since.elapsed())
+        {
+            return Err(TimeStepChangeError::MinimumTimeNotReached(remaining));
         }
         self.current_index += 1;
-        self.change_time = Instant::now();
+        self.running_slow_since = None;
         Ok(self.current_timestep())
     }
 
     /// Decrease the timestep. This corresponds to more updates per second.
+    ///
+    /// Shouldn't be called from outside the `PhysicsStepperSystem`, otherwise bad things may happen.
     pub fn decrease_timestep(&mut self) -> Result<f32, TimeStepChangeError> {
         if self.current_index <= 0 {
             return Err(TimeStepChangeError::MinimumTimestepReached);
         }
-        if let Some(remaining) = self.minimum_age.checked_sub(self.change_time.elapsed()) {
-            return Err(TimeStepChangeError::MinimumAgeNotReached(remaining));
+        let running_slow_since = match self.running_slow_since {
+            Some(time) => time,
+            None => return Err(TimeStepChangeError::NotRunningSlow),
+        };
+        if let Some(remaining) = self
+            .minimum_slow_time
+            .checked_sub(running_slow_since.elapsed())
+        {
+            return Err(TimeStepChangeError::MinimumTimeNotReached(remaining));
         }
         self.current_index -= 1;
-        self.change_time = Instant::now();
+        self.running_slow_since = None;
         Ok(self.current_timestep())
     }
 
     /// Get the currently used timestep.
     pub fn current_timestep(&self) -> f32 {
         self.time_steps[self.current_index]
+    }
+
+    /// Set whether physics are currently running slow or not. Intended to be called every frame as changing
+    /// values only happens when `is_running_slow` changes between calls.
+    ///
+    /// Shouldn't be called from outside the `PhysicsStepperSystem`, otherwise bad things may happen.
+    pub fn set_running_slow(&mut self, is_running_slow: bool) {
+        self.running_slow_since = match (self.running_slow_since, is_running_slow) {
+            (None, true) => {
+                warn!("Physics seem to be running slow! Timestep will be changed if we keep running slow.");
+                Some(Instant::now())
+            }
+            (Some(_), false) => {
+                debug!("Physics aren't running slow anymore.");
+                None
+            }
+            (_, _) => self.running_slow_since,
+        }
+    }
+
+    /// Get whether physics have been running slow for the specified minimum time and thus the timestep should
+    /// be increased.
+    pub fn should_increase_timestep(&self) -> bool {
+        match self.running_slow_since {
+            None => false,
+            Some(time) => time.elapsed() > self.minimum_slow_time,
+        }
     }
 }

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -94,4 +94,13 @@ impl TimeStepConstraint {
     pub fn current_timestep(&self) -> f32 {
         self.time_steps[self.current_index]
     }
+
+    /// Get next smaller timestep.
+    pub fn smaller_timestep(&self) -> Option<f32> {
+        if self.current_index <= 0 {
+            None
+        } else {
+            Some(self.time_steps[self.current_index - 1])
+        }
+    }
 }

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -73,7 +73,7 @@ impl TimeStepConstraint {
     }
 
     /// Increase the timestep. This corresponds to fewer updates per seconds.
-    pub fn increase_timestep(&mut self) -> Result<(), TimeStepChangeError> {
+    pub fn increase_timestep(&mut self) -> Result<f32, TimeStepChangeError> {
         if self.current_index >= self.time_steps.len() - 1 {
             return Err(TimeStepChangeError::MaximumTimestepReached);
         }
@@ -82,7 +82,7 @@ impl TimeStepConstraint {
         }
         self.current_index += 1;
         self.change_time = Instant::now();
-        Ok(())
+        Ok(self.current_timestep())
     }
 
     /// Get the currently used timestep.

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -93,18 +93,8 @@ impl TimeStepConstraint {
         if self.current_index >= self.time_steps.len() - 1 {
             return Err(TimeStepChangeError::MaximumTimestepReached);
         }
-        let running_slow_since = match self.running_slow_since {
-            Some(time) => time,
-            None => return Err(TimeStepChangeError::NotRunningSlow),
-        };
-        if let Some(remaining) = self
-            .minimum_slow_time
-            .checked_sub(running_slow_since.elapsed())
-        {
-            return Err(TimeStepChangeError::MinimumTimeNotReached(remaining));
-        }
         self.current_index += 1;
-        self.running_slow_since = None;
+        self.set_running_slow(false);
         Ok(self.current_timestep())
     }
 
@@ -115,18 +105,8 @@ impl TimeStepConstraint {
         if self.current_index <= 0 {
             return Err(TimeStepChangeError::MinimumTimestepReached);
         }
-        let running_slow_since = match self.running_slow_since {
-            Some(time) => time,
-            None => return Err(TimeStepChangeError::NotRunningSlow),
-        };
-        if let Some(remaining) = self
-            .minimum_slow_time
-            .checked_sub(running_slow_since.elapsed())
-        {
-            return Err(TimeStepChangeError::MinimumTimeNotReached(remaining));
-        }
         self.current_index -= 1;
-        self.running_slow_since = None;
+        self.set_running_slow(false);
         Ok(self.current_timestep())
     }
 

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -91,6 +91,19 @@ impl TimeStepConstraint {
         Ok(self.current_timestep())
     }
 
+    /// Decrease the timestep. This corresponds to more updates per second.
+    pub fn decrease_timestep(&mut self) -> Result<f32, TimeStepChangeError> {
+        if self.current_index <= 0 {
+            return Err(TimeStepChangeError::MinimumTimestepReached);
+        }
+        if let Some(remaining) = self.minimum_age.checked_sub(self.change_time.elapsed()) {
+            return Err(TimeStepChangeError::MinimumAgeNotReached(remaining));
+        }
+        self.current_index -= 1;
+        self.change_time = Instant::now();
+        Ok(self.current_timestep())
+    }
+
     /// Get the currently used timestep.
     pub fn current_timestep(&self) -> f32 {
         self.time_steps[self.current_index]

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -42,17 +42,19 @@ pub struct TimeStepConstraint {
     time_steps: Vec<f32>,
     /// Index of the currently used timestep.
     current_index: usize,
+    /// Fraction of frame time physics are allowed to take.
+    max_physics_time_fraction: f32,
 }
 
 impl TimeStepConstraint {
-    /// Creates a new `TimeStepConstraint` from the specified timesteps to use and the minimum time of running
-    /// slowly before changing timesteps. The timestep will be increased if physics have been lagging behind for
-    /// the last `minimum_slow_time`.
+    /// Creates a new `TimeStepConstraint` from the specified timesteps to use and the maximum physics
+    /// time fraction. If physics take more than the specified fraction of frame time, the timestep
+    /// will be increased.
     ///
     /// # Panics
     ///
     /// This constructor will panic if no timesteps are given or if any negative timesteps are specified.
-    pub fn new(time_steps: impl Into<Vec<f32>>) -> Self {
+    pub fn new(time_steps: impl Into<Vec<f32>>, max_physics_time_fraction: f32) -> Self {
         let mut time_steps = time_steps.into();
         assert!(
             !time_steps.is_empty(),
@@ -65,6 +67,7 @@ impl TimeStepConstraint {
         Self {
             time_steps,
             current_index: 0,
+            max_physics_time_fraction,
         }
     }
 
@@ -102,5 +105,10 @@ impl TimeStepConstraint {
         } else {
             Some(self.time_steps[self.current_index - 1])
         }
+    }
+
+    /// Get the fraction of frame time physics are allowed to take.
+    pub fn max_physics_time_fraction(&self) -> f32 {
+        self.max_physics_time_fraction
     }
 }

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::Ordering,
-    time::{Duration, Instant},
-};
+use std::cmp::Ordering;
 
 /// The type of time step to use for the physics simulation.
 pub enum TimeStep {
@@ -24,10 +21,6 @@ pub enum TimeStepChangeError {
     MinimumTimestepReached,
     /// No larger timestep available.
     MaximumTimestepReached,
-    /// Physics haven't been running slow for long enough to change the timestep.
-    MinimumTimeNotReached(Duration),
-    /// Physics aren't running slow.
-    NotRunningSlow,
 }
 
 impl std::fmt::Display for TimeStepChangeError {
@@ -39,11 +32,6 @@ impl std::fmt::Display for TimeStepChangeError {
             TimeStepChangeError::MinimumTimestepReached => {
                 write!(f, "No smaller timestep available!")
             }
-            TimeStepChangeError::MinimumTimeNotReached(remaining) => {
-                let time = remaining.as_secs() as f32 + remaining.subsec_nanos() as f32 * 1e-9;
-                write!(f, "Timestep can be changed in {:.4} seconds", time)
-            }
-            TimeStepChangeError::NotRunningSlow => write!(f, "Simulation is not running slow"),
         }
     }
 }
@@ -54,10 +42,6 @@ pub struct TimeStepConstraint {
     time_steps: Vec<f32>,
     /// Index of the currently used timestep.
     current_index: usize,
-    /// Time when the simulation started running slow.
-    running_slow_since: Option<Instant>,
-    /// Minimum time the simulation has to be running slow before the timestep is changed.
-    minimum_slow_time: Duration,
 }
 
 impl TimeStepConstraint {
@@ -68,7 +52,7 @@ impl TimeStepConstraint {
     /// # Panics
     ///
     /// This constructor will panic if no timesteps are given or if any negative timesteps are specified.
-    pub fn new(time_steps: impl Into<Vec<f32>>, minimum_slow_time: Duration) -> Self {
+    pub fn new(time_steps: impl Into<Vec<f32>>) -> Self {
         let mut time_steps = time_steps.into();
         assert!(
             !time_steps.is_empty(),
@@ -81,8 +65,6 @@ impl TimeStepConstraint {
         Self {
             time_steps,
             current_index: 0,
-            minimum_slow_time,
-            running_slow_since: None,
         }
     }
 
@@ -94,7 +76,6 @@ impl TimeStepConstraint {
             return Err(TimeStepChangeError::MaximumTimestepReached);
         }
         self.current_index += 1;
-        self.set_running_slow(false);
         Ok(self.current_timestep())
     }
 
@@ -106,39 +87,11 @@ impl TimeStepConstraint {
             return Err(TimeStepChangeError::MinimumTimestepReached);
         }
         self.current_index -= 1;
-        self.set_running_slow(false);
         Ok(self.current_timestep())
     }
 
     /// Get the currently used timestep.
     pub fn current_timestep(&self) -> f32 {
         self.time_steps[self.current_index]
-    }
-
-    /// Set whether physics are currently running slow or not. Intended to be called every frame as changing
-    /// values only happens when `is_running_slow` changes between calls.
-    ///
-    /// Shouldn't be called from outside the `PhysicsStepperSystem`, otherwise bad things may happen.
-    pub fn set_running_slow(&mut self, is_running_slow: bool) {
-        self.running_slow_since = match (self.running_slow_since, is_running_slow) {
-            (None, true) => {
-                warn!("Physics seem to be running slow! Timestep will be changed if we keep running slow.");
-                Some(Instant::now())
-            }
-            (Some(_), false) => {
-                debug!("Physics aren't running slow anymore.");
-                None
-            }
-            (_, _) => self.running_slow_since,
-        }
-    }
-
-    /// Get whether physics have been running slow for the specified minimum time and thus the timestep should
-    /// be increased.
-    pub fn should_increase_timestep(&self) -> bool {
-        match self.running_slow_since {
-            None => false,
-            Some(time) => time.elapsed() > self.minimum_slow_time,
-        }
     }
 }

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -11,6 +11,12 @@ pub enum TimeStep {
     SemiFixed(TimeStepConstraint),
 }
 
+impl Default for TimeStep {
+    fn default() -> Self {
+        TimeStep::Fixed(1. / 120.)
+    }
+}
+
 /// Error when trying to change the actual timestep for a semi-fixed timestep.
 #[derive(Debug)]
 pub enum TimeStepChangeError {

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -1,0 +1,92 @@
+use std::{
+    cmp::Ordering,
+    time::{Duration, Instant},
+};
+
+/// The type of time step to use for the physics simulation.
+pub enum TimeStep {
+    /// Physics will always use the given timestep.TimeStepChangeError.
+    Fixed(f32),
+    /// Physics use one of the given timesteps, chaning when physics are falling behind.
+    SemiFixed(TimeStepConstraint),
+}
+
+/// Error when trying to change the actual timestep for a semi-fixed timestep.
+#[derive(Debug)]
+pub enum TimeStepChangeError {
+    MinimumTimestepReached,
+    MaximumTimestepReached,
+    MinimumAgeNotReached(Duration),
+}
+
+impl std::fmt::Display for TimeStepChangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            TimeStepChangeError::MaximumTimestepReached => {
+                write!(f, "No larger timestep available!")
+            }
+            TimeStepChangeError::MinimumTimestepReached => {
+                write!(f, "No smaller timestep available!")
+            }
+            TimeStepChangeError::MinimumAgeNotReached(remaining) => {
+                let time = remaining.as_secs() as f32 + remaining.subsec_nanos() as f32 * 1e-9;
+                write!(f, "Timestep can be changed in {:.4} seconds", time)
+            }
+        }
+    }
+}
+
+/// Constraints for a semi-fixed timestep.
+pub struct TimeStepConstraint {
+    /// Vector of possible timesteps to use.
+    time_steps: Vec<f32>,
+    /// Index of the currently used timestep.
+    current_index: usize,
+    /// Time when the timestep was last changed.
+    change_time: Instant,
+    /// Minimum time after changing the timestep before it can be changed again.
+    minimum_age: Duration,
+}
+
+impl TimeStepConstraint {
+    /// Creates a new `TimeStepConstraint` from the specified timesteps to use and the minimum time between changing timesteps.
+    ///
+    /// # Panics
+    ///
+    /// This constructor will panic if no timesteps are given or if any negative timesteps are specified.
+    pub fn new(time_steps: impl Into<Vec<f32>>, minimum_age: Duration) -> Self {
+        let mut time_steps = time_steps.into();
+        assert!(
+            !time_steps.is_empty(),
+            "No timesteps given in TimeStepConstraint"
+        );
+        time_steps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        time_steps.dedup();
+        assert!(time_steps[0] > 0., "Negative timesteps are not allowed");
+
+        Self {
+            time_steps,
+            current_index: 0,
+            change_time: Instant::now(),
+            minimum_age,
+        }
+    }
+
+    /// Increase the timestep. This corresponds to fewer updates per seconds.
+    pub fn increase_timestep(&mut self) -> Result<(), TimeStepChangeError> {
+        if self.current_index >= self.time_steps.len() - 1 {
+            return Err(TimeStepChangeError::MaximumTimestepReached);
+        }
+        if let Some(remaining) = self.minimum_age.checked_sub(self.change_time.elapsed()) {
+            return Err(TimeStepChangeError::MinimumAgeNotReached(remaining));
+        }
+        self.current_index += 1;
+        self.change_time = Instant::now();
+        Ok(())
+    }
+
+    /// Get the currently used timestep.
+    pub fn current_timestep(&self) -> f32 {
+        self.time_steps[self.current_index]
+    }
+}

--- a/src/time_step.rs
+++ b/src/time_step.rs
@@ -5,9 +5,9 @@ use std::{
 
 /// The type of time step to use for the physics simulation.
 pub enum TimeStep {
-    /// Physics will always use the given timestep.TimeStepChangeError.
+    /// Physics will always use the given timestep.
     Fixed(f32),
-    /// Physics use one of the given timesteps, chaning when physics are falling behind.
+    /// Physics use one of the given timesteps, changing when physics are falling behind.
     SemiFixed(TimeStepConstraint),
 }
 
@@ -78,7 +78,7 @@ impl TimeStepConstraint {
         }
     }
 
-    /// Increase the timestep. This corresponds to fewer updates per seconds.
+    /// Increase the timestep. This corresponds to fewer updates per second.
     pub fn increase_timestep(&mut self) -> Result<f32, TimeStepChangeError> {
         if self.current_index >= self.time_steps.len() - 1 {
             return Err(TimeStepChangeError::MaximumTimestepReached);


### PR DESCRIPTION
This is a WIP implementation of a semi-fixed timestep as discussed in #13. This PR makes the timestep used for physics configurable as either fixed (constant timestep is used) or semi-fixed (one of a given set of possible timesteps is used). I've also added two new methods to the `PhysicsBundle` to configure the timestep. The default timestep is now fixed to 1/120 seconds.

If a semi-fixed timestep is used, the `PhysicsStepperSystem` will try to raise the timestep if physics are falling behind, but currently the timestep will not be lowered again (this is why this PR is a WIP).