### PR TITLE
Backport of fixes from old `Changes` branch.

### DIFF
--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -1,7 +1,7 @@
 use amethyst::ecs::{Component, FlaggedStorage};
 use nalgebra::Matrix3;
 use nphysics3d::math::{Force, Point, Velocity};
-use nphysics3d::object::BodyHandle;
+use nphysics3d::object::{BodyHandle, BodyStatus};
 
 /// Rigid physics body, for use in `PhysicsBody` Component.
 /// Currently only the velocity is read and updated at runtime.
@@ -19,6 +19,8 @@ pub struct DynamicBody {
     pub center_of_mass: Point<f32>,
 
     pub external_forces: Force<f32>,
+    #[serde(skip)]
+    pub body_status: BodyStatus,
 }
 
 impl DynamicBody {
@@ -34,6 +36,7 @@ impl DynamicBody {
             angular_mass,
             center_of_mass,
             external_forces: Force::<f32>::zero(),
+            body_status: BodyStatus::Dynamic,
         }
     }
 
@@ -50,6 +53,7 @@ impl DynamicBody {
             angular_mass,
             center_of_mass,
             external_forces: Force::<f32>::zero(),
+            body_status: BodyStatus::Dynamic,
         }
     }
 

--- a/src/systems/sync_bodies_from_physics.rs
+++ b/src/systems/sync_bodies_from_physics.rs
@@ -140,9 +140,7 @@ impl<'a> System<'a> for SyncBodiesFromPhysicsSystem {
                 }
             }).collect::<Vec<_>>();
 
-        contact_events.iter_write(
-            contact_ev.into_iter()
-        );
+        contact_events.iter_write(contact_ev.into_iter());
 
         let proximity_ev = collision_world
                 .proximity_events()
@@ -161,9 +159,7 @@ impl<'a> System<'a> for SyncBodiesFromPhysicsSystem {
                     }
                 }).collect::<Vec<_>>();
 
-        proximity_events.iter_write(
-            proximity_ev.into_iter()
-        );
+        proximity_events.iter_write(proximity_ev.into_iter());
     }
 }
 

--- a/src/systems/sync_bodies_from_physics.rs
+++ b/src/systems/sync_bodies_from_physics.rs
@@ -122,35 +122,47 @@ impl<'a> System<'a> for SyncBodiesFromPhysicsSystem {
 
         let collision_world = physical_world.collision_world();
 
-        contact_events.iter_write(collision_world.contact_events().iter().cloned().map(|ev| {
-            trace!("Emitting contact event: {:?}", ev);
+        let contact_ev = collision_world.contact_events().iter().cloned().flat_map(|ev| {
+                trace!("Emitting contact event: {:?}", ev);
 
-            let (handle1, handle2) = match ev {
-                ContactEvent::Started(h1, h2) => (h1, h2),
-                ContactEvent::Stopped(h1, h2) => (h1, h2),
-            };
+                let (handle1, handle2) = match ev {
+                    ContactEvent::Started(h1, h2) => (h1, h2),
+                    ContactEvent::Stopped(h1, h2) => (h1, h2),
+                };
 
-            let e1 = entity_from_handle(&entities, &colliders, handle1)
-                .expect("Failed to find entity for collider.");
-            let e2 = entity_from_handle(&entities, &colliders, handle2)
-                .expect("Failed to find entity for collider.");
-            (e1, e2, ev)
-        }));
+                let e1 = entity_from_handle(&entities, &colliders, handle1);
+                let e2 = entity_from_handle(&entities, &colliders, handle2);
+                if let (Some(e1), Some(e2)) = (e1, e2) {
+                    Some((e1, e2, ev))
+                } else {
+                    error!("Failed to find entity for collider during contact event iteration. Was the entity removed?");
+                    None
+                }
+            }).collect::<Vec<_>>();
 
-        proximity_events.iter_write(
-            collision_world
+        contact_events.iter_write(
+            contact_ev.into_iter()
+        );
+
+        let proximity_ev = collision_world
                 .proximity_events()
                 .iter()
                 .cloned()
-                .map(|ev| {
+                .flat_map(|ev| {
                     trace!("Emitting proximity event: {:?}", ev);
 
-                    let e1 = entity_from_handle(&entities, &colliders, ev.collider1)
-                        .expect("Failed to find entity for collider.");
-                    let e2 = entity_from_handle(&entities, &colliders, ev.collider2)
-                        .expect("Failed to find entity for collider.");
-                    (e1, e2, ev)
-                }),
+                    let e1 = entity_from_handle(&entities, &colliders, ev.collider1);
+                    let e2 = entity_from_handle(&entities, &colliders, ev.collider2);
+                    if let (Some(e1), Some(e2)) = (e1, e2) {
+                        Some((e1, e2, ev))
+                    } else {
+                        error!("Failed to find entity for collider during proximity event iteration. Was the entity removed?");
+                        None
+                    }
+                }).collect::<Vec<_>>();
+
+        proximity_events.iter_write(
+            proximity_ev.into_iter()
         );
     }
 }

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -105,7 +105,6 @@ impl<'a> System<'a> for SyncBodiesToPhysicsSystem {
             } else if modified_transforms.contains(id) || modified_physics_bodies.contains(id) {
                 trace!("Detected changed dynamics body with id {}", id);
                 if let Some(physical_body) = physical_world.rigid_body_mut(body.handle.unwrap()) {
-
                     // if you changed the mass properties at all... too bad!
                     match try_convert(transform.0) {
                         Some(p) => {
@@ -121,7 +120,9 @@ impl<'a> System<'a> for SyncBodiesToPhysicsSystem {
                             body.external_forces = Force::<f32>::zero();
                             physical_body.set_status(body.body_status);
                         }
-                        None => error!("Failed to convert entity position from `Transform` to physics systems"),
+                        None => error!(
+                            "Failed to convert entity position from `Transform` to physics systems"
+                        ),
                     }
                 }
             }

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -99,23 +99,30 @@ impl<'a> System<'a> for SyncBodiesToPhysicsSystem {
                 physical_body.set_velocity(body.velocity);
                 physical_body.apply_force(&body.external_forces);
                 body.external_forces = Force::<f32>::zero();
+                physical_body.set_status(body.body_status);
 
                 trace!("Velocity and external forces applied, external forces reset to zero, for body with handle: {:?}", body.handle);
             } else if modified_transforms.contains(id) || modified_physics_bodies.contains(id) {
                 trace!("Detected changed dynamics body with id {}", id);
                 if let Some(physical_body) = physical_world.rigid_body_mut(body.handle.unwrap()) {
-                    let position: Isometry<f32> = try_convert(transform.0).unwrap();
-                    trace!(
-                        "Updating rigid body in physics world with isometry: {}",
-                        position
-                    );
-                    physical_body.set_position(position);
-
-                    physical_body.set_velocity(body.velocity);
-                    physical_body.apply_force(&body.external_forces);
-                    body.external_forces = Force::<f32>::zero();
 
                     // if you changed the mass properties at all... too bad!
+                    match try_convert(transform.0) {
+                        Some(p) => {
+                            let position: Isometry<f32> = p;
+                            trace!(
+                                "Updating rigid body in physics world with isometry: {}",
+                                position
+                            );
+                            physical_body.set_position(position);
+
+                            physical_body.set_velocity(body.velocity);
+                            physical_body.apply_force(&body.external_forces);
+                            body.external_forces = Force::<f32>::zero();
+                            physical_body.set_status(body.body_status);
+                        }
+                        None => error!("Failed to convert entity position from `Transform` to physics systems"),
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added body status (kinematic, static, etc).
Fix crash when position is NaN.
Fix entity not found for collisions when deleting entities on the same frame a collision occurs.